### PR TITLE
Fixes and improvements

### DIFF
--- a/CustomItems/CustomItems.csproj
+++ b/CustomItems/CustomItems.csproj
@@ -73,9 +73,6 @@
       <HintPath>..\packages\EXILED.2.4.2-beta\lib\net472\Exiled.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Example, Version=2.4.1.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\EXILED\bin\Release\Exiled.Example.dll</HintPath>
-    </Reference>
     <Reference Include="Exiled.Loader, Version=2.4.2.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\EXILED.2.4.2-beta\lib\net472\Exiled.Loader.dll</HintPath>
       <Private>True</Private>
@@ -91,8 +88,8 @@
     <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(EXILED_REFERENCES)\Mirror.dll</HintPath>
     </Reference>
-    <Reference Include="Subclass, Version=1.3.3.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>bin\Release\Subclass.dll</HintPath>
+    <Reference Include="Subclass">
+      <HintPath>$(EXILED_REFERENCES)\Subclass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/CustomItems/Items/TranquilizerGun.cs
+++ b/CustomItems/Items/TranquilizerGun.cs
@@ -160,7 +160,7 @@ namespace CustomItems.Items
             if (ragdoll != null)
                 NetworkServer.Destroy(ragdoll.gameObject);
 
-            if (player == null)
+            if (player.GameObject == null)
                 yield break;
 
             newHealth = player.Health;
@@ -169,7 +169,9 @@ namespace CustomItems.Items
             player.Scale = previousScale;
             player.Health = newHealth;
             player.IsInvisible = false;
-            player.Inventory.curItem = previousItem;
+
+            if (!DropItems)
+                player.Inventory.curItem = previousItem;
 
             if (Warhead.IsDetonated && player.Position.y < 900)
             {

--- a/CustomItems/Items/TranquilizerGun.cs
+++ b/CustomItems/Items/TranquilizerGun.cs
@@ -10,18 +10,20 @@ namespace CustomItems.Items
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
+    using CustomPlayerEffects;
     using Exiled.API.Features;
     using Exiled.CustomItems.API;
     using Exiled.CustomItems.API.Features;
     using Exiled.CustomItems.API.Spawn;
     using Exiled.Events.EventArgs;
     using MEC;
+    using Mirror;
     using UnityEngine;
 
     /// <inheritdoc />
     public class TranquilizerGun : CustomWeapon
     {
-        private readonly Dictionary<Player, int> tranquilizedPlayers = new Dictionary<Player, int>();
+        private readonly Dictionary<Player, float> tranquilizedPlayers = new Dictionary<Player, float>();
 
         /// <inheritdoc/>
         public override uint Id { get; set; } = 11;
@@ -76,7 +78,7 @@ namespace CustomItems.Items
         /// Gets or sets the exponential modifier used to determine how much time is removed from the effect, everytime a player is tranquilized, they gain a resistance to further tranquilizations, reducing the duration of future effects.
         /// </summary>
         [Description("Everytime a player is tranquilized, they gain a resistance to further tranquilizations, reducing the duration of future effects. This number signifies the exponential modifier used to determine how much time is removed from the effect.")]
-        public int ResistanceModifier { get; set; } = 2;
+        public float ResistanceModifier { get; set; } = 1.2f;
 
         /// <summary>
         /// Gets or sets a value indicating whether or not tranquilized targets should drop all of their items.
@@ -91,48 +93,91 @@ namespace CustomItems.Items
         public int ScpResistChance { get; set; } = 40;
 
         /// <inheritdoc/>
+        public override void Destroy()
+        {
+            tranquilizedPlayers.Clear();
+
+            base.Destroy();
+        }
+
+        /// <inheritdoc/>
         protected override void OnHurting(HurtingEventArgs ev)
         {
-            if (!Check(ev.Attacker.CurrentItem) || ev.Attacker == ev.Target)
+            base.OnHurting(ev);
+
+            if (ev.Attacker == ev.Target || (ev.Target.Team == Team.SCP && ResistantScps && Random.Range(1, 101) <= ScpResistChance))
                 return;
 
-            ev.Amount = Damage;
+            float duration = Duration;
 
-            if (ev.Target.Team == Team.SCP && ResistantScps)
-                if (UnityEngine.Random.Range(1, 101) <= ScpResistChance)
-                    return;
+            if (!tranquilizedPlayers.TryGetValue(ev.Target, out _))
+                tranquilizedPlayers.Add(ev.Target, 1);
 
-            float dur = Duration;
-            if (!tranquilizedPlayers.ContainsKey(ev.Target))
-                tranquilizedPlayers.Add(ev.Target, 0);
+            tranquilizedPlayers[ev.Target] *= ResistanceModifier;
 
-            dur -= tranquilizedPlayers[ev.Target] * ResistanceModifier;
+            duration -= tranquilizedPlayers[ev.Target];
 
-            if (dur > 0f)
-                Timing.RunCoroutine(DoTranquilize(ev.Target, dur));
+            if (duration > 0f)
+                Timing.RunCoroutine(DoTranquilize(ev.Target, duration));
         }
 
         private IEnumerator<float> DoTranquilize(Player player, float duration)
         {
-            Vector3 pos = player.Position;
+            Vector3 oldPosition = player.Position;
+            ItemType previousItem = player.Inventory.curItem;
+            Vector3 previousScale = player.Scale;
+            float newHealth = player.Health - Damage;
 
-            foreach (Inventory.SyncItemInfo item in player.Inventory.items.ToList())
-            {
-                if (TryGet(item, out CustomItem cItem))
-                    cItem.Spawn(player.Position);
-                player.Inventory.items.Remove(item);
-            }
+            if (newHealth <= 0)
+                yield break;
 
             if (DropItems)
-                player.DropItems();
+            {
+                foreach (Inventory.SyncItemInfo item in player.Inventory.items.ToList())
+                {
+                    if (TryGet(item, out CustomItem customItem))
+                        customItem.Spawn(player.Position, item);
 
-            Ragdoll ragdoll = Map.SpawnRagdoll(player, DamageTypes.None, pos, allowRecall: false);
-            player.Position = new Vector3(0, 0, 0);
+                    player.Inventory.items.Remove(item);
+                }
+
+                player.DropItems();
+            }
+
+            Ragdoll ragdoll = Map.SpawnRagdoll(player, DamageTypes.None, oldPosition, allowRecall: false);
+
+            player.Inventory.curItem = ItemType.None;
+            player.IsInvisible = true;
+            player.Scale = Vector3.one * 0.2f;
+            player.Health = newHealth;
+            player.IsGodModeEnabled = true;
+
+            player.EnableEffect<Amnesia>(duration);
+            player.EnableEffect<Ensnared>(duration);
 
             yield return Timing.WaitForSeconds(duration);
 
-            player.Position = pos;
-            Object.Destroy(ragdoll.gameObject);
+            if (ragdoll != null)
+                NetworkServer.Destroy(ragdoll.gameObject);
+
+            if (player == null)
+                yield break;
+
+            newHealth = player.Health;
+
+            player.IsGodModeEnabled = false;
+            player.Scale = previousScale;
+            player.Health = newHealth;
+            player.IsInvisible = false;
+            player.Inventory.curItem = previousItem;
+
+            if (Warhead.IsDetonated && player.Position.y < 900)
+            {
+                player.Kill(DamageTypes.Nuke);
+                yield break;
+            }
+
+            player.Position = oldPosition;
         }
     }
 }


### PR DESCRIPTION
+ Fixed TranquilizerGun not increasing the resistance properly after each hit. Decreased TranquilizerGun::ResistanceModifier from 2 to 1.2 by default to reflect these changes.
+ Fixed a bug that removed CustomItems inside tranquilized players' inventory even with TranquilizerGun::DropItems set to false.
+ Fixed a bug that didn't allow to change the TranquilizerGun Damage.
+ Tranquilized players are now cleared when Destroying the custom weapon.
+ Improved TranquilizerGun::DoTranquilize effect to not teleport players to (0, 0, 0).