### PR TITLE
C4 charges updated with a new feature and minor code tweaks with SCP-714

### DIFF
--- a/CustomItems/Commands/C4Charge.cs
+++ b/CustomItems/Commands/C4Charge.cs
@@ -52,8 +52,7 @@ namespace CustomItems.Commands
 
                 if (Vector3.Distance(charge.Key.transform.position, ply.Position) < Items.C4Charge.Instance.MaxDistance)
                 {
-                    charge.Key.NetworkfuseTime = 0.1f;
-                    Items.C4Charge.PlacedCharges.Remove(charge.Key);
+                    Items.C4Charge.Instance.C4Handler(charge.Key);
 
                     i++;
                 }

--- a/CustomItems/CustomItems.csproj
+++ b/CustomItems/CustomItems.csproj
@@ -53,37 +53,29 @@
     <Reference Include="CommandSystem.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(EXILED_REFERENCES)\CommandSystem.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.API, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.API.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.API, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.API.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Bootstrap, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.Bootstrap.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.Bootstrap, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.Bootstrap.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.CreditTags, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.CreditTags.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.CreditTags, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.CreditTags.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.CustomItems, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.CustomItems.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.CustomItems, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.CustomItems.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Events, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.Events.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.Events, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.Events.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Loader, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.Loader.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.Loader, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.Loader.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Permissions, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.Permissions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.Permissions, Version=2.9.4.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.Permissions.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.2.9.0-beta\lib\net472\Exiled.Updater.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\EXILED.2.9.4-beta\lib\net472\Exiled.Updater.dll</HintPath>
     </Reference>
     <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(EXILED_REFERENCES)\Mirror.dll</HintPath>

--- a/CustomItems/Items/C4Charge.cs
+++ b/CustomItems/Items/C4Charge.cs
@@ -175,17 +175,18 @@ namespace CustomItems.Items
         /// <inheritdoc/>
         protected override void OnThrowing(ThrowingGrenadeEventArgs ev)
         {
-            if (Check(ev.Player.CurrentItem))
-            {
-                ev.IsAllowed = false;
+            ev.IsAllowed = false;
+            ev.Player.RemoveItem(ev.Player.CurrentItem);
 
-                ev.Player.RemoveItem(ev.Player.CurrentItem);
+            float slowThrowMultiplier = 0.1f;
 
-                var c4 = Spawn(ev.Player.CameraTransform.position, (ev.Player.Rotation * ThrowMultiplier) + (Vector3.up * 1.5f), FuseTime, ItemType.GrenadeFrag, ev.Player);
+            if (!ev.IsSlow)
+                slowThrowMultiplier = 1f;
 
-                if (!PlacedCharges.ContainsKey(c4))
-                    PlacedCharges.Add(c4, ev.Player);
-            }
+            Grenade c4 = Spawn(ev.Player.CameraTransform.position, (ev.Player.Rotation * ThrowMultiplier * slowThrowMultiplier) + (Vector3.up * 1.5f), FuseTime, ItemType.GrenadeFrag, ev.Player);
+
+            if (!PlacedCharges.ContainsKey(c4))
+                PlacedCharges.Add(c4, ev.Player);
 
             base.OnThrowing(ev);
         }

--- a/CustomItems/Items/Scp714.cs
+++ b/CustomItems/Items/Scp714.cs
@@ -7,8 +7,11 @@
 
 namespace CustomItems.Items
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using Exiled.API.Enums;
+    using Exiled.API.Features;
     using Exiled.CustomItems.API;
     using Exiled.CustomItems.API.Features;
     using Exiled.CustomItems.API.Spawn;
@@ -86,13 +89,18 @@ namespace CustomItems.Items
         /// <inheritdoc/>
         protected override void OnDropping(DroppingItemEventArgs ev)
         {
-            if (Check(ev.Item))
-            {
-                ev.Player.ShowHint(TakeOffMessage);
+            ev.Player.ShowHint(TakeOffMessage);
 
-                foreach (string effect in Scp714Effects)
+            foreach (string effect in Scp714Effects)
+            {
+                try
                 {
-                    ev.Player.ReferenceHub.playerEffectsController.ChangeByString(effect, 0);
+                    ev.Player.DisableEffect((EffectType)Enum.Parse(typeof(EffectType), effect, true));
+                }
+                catch (Exception)
+                {
+                    Log.Error($"\"{effect}\" is not a valid effect name.");
+                    continue;
                 }
             }
 
@@ -105,7 +113,10 @@ namespace CustomItems.Items
             {
                 foreach (string effect in Scp714Effects)
                 {
-                    ev.Player.ReferenceHub.playerEffectsController.EnableByString(effect, 999f, false);
+                    if (!ev.Player.EnableEffect(effect, 999f, false))
+                    {
+                        Log.Error($"\"{effect}\" is not a valid effect name.");
+                    }
                 }
             }
             else
@@ -117,7 +128,15 @@ namespace CustomItems.Items
 
                 foreach (string effect in Scp714Effects)
                 {
-                    ev.Player.ReferenceHub.playerEffectsController.ChangeByString(effect, 0);
+                    try
+                    {
+                        ev.Player.DisableEffect((EffectType)Enum.Parse(typeof(EffectType), effect, true));
+                    }
+                    catch (Exception)
+                    {
+                        Log.Error($"\"{effect}\" is not a valid effect name.");
+                        continue;
+                    }
                 }
             }
         }

--- a/CustomItems/packages.config
+++ b/CustomItems/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="2.9.0-beta" targetFramework="net472" />
+  <package id="EXILED" version="2.9.4-beta" targetFramework="net472" />
   <package id="Lib.Harmony" version="2.0.4" targetFramework="net472" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
# Changelog:

## C4-119
- Added a new feature which allows to shot C4 charges. By default it will delete them without exploding.
- Added C4 enum and handler which cleaned up code a bit

Because I didn't know how Raycasts work I used some code from Build's SCP-035

## SCP-714
- Removed unneccessary `Check()` in `protected override` method
- Added `Log.Error()` which will show in server's console if effect name is not valid
