### PR TITLE
READ THE COMMENT FOR MORE INFO

### DIFF
--- a/CustomItems/Components/Rock.cs
+++ b/CustomItems/Components/Rock.cs
@@ -74,7 +74,7 @@ namespace CustomItems.Components
                     Player.Get(Owner).ShowHitMarker(1f);
                 }
 
-                CustomItem.Registered.First(customItem => customItem.Name == "Rock").Spawn(collision.GetContact(0).point + Vector3.up);
+                CustomItem.Registered.First(customItem => customItem.Name == "Rock").Spawn(collision.GetContact(0).point + Vector3.up, Player.Get(Owner));
                 Destroy(gameObject);
             }
             catch (Exception exception)

--- a/CustomItems/CustomItems.cs
+++ b/CustomItems/CustomItems.cs
@@ -11,7 +11,6 @@ namespace CustomItems
     using System;
     using Events;
     using Exiled.API.Features;
-    using Exiled.CustomItems.API;
     using Exiled.CustomItems.API.Features;
     using HarmonyLib;
     using Server = Exiled.Events.Handlers.Server;
@@ -34,7 +33,7 @@ namespace CustomItems
         public static CustomItems Instance { get; private set; }
 
         /// <inheritdoc/>
-        public override Version RequiredExiledVersion { get; } = new Version(5, 0, 0);
+        public override Version RequiredExiledVersion { get; } = new Version(5, 2, 2);
 
         /// <inheritdoc/>
         public override void OnEnabled()

--- a/CustomItems/CustomItems.csproj
+++ b/CustomItems/CustomItems.csproj
@@ -45,56 +45,57 @@
       <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net472\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\References\Assembly-CSharp-Publicized.dll</HintPath>
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Assembly-CSharp-Publicized.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="CommandSystem.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\CommandSystem.Core.dll</HintPath>
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\CommandSystem.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.API, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.API.dll</HintPath>
+    <Reference Include="Exiled.API, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.API.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Bootstrap, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.Bootstrap.dll</HintPath>
+    <Reference Include="Exiled.Bootstrap, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.Bootstrap.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.CreditTags, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.CreditTags.dll</HintPath>
+    <Reference Include="Exiled.CreditTags, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.CreditTags.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.CustomItems, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.CustomItems.dll</HintPath>
+    <Reference Include="Exiled.CustomItems, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.CustomItems.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.CustomRoles, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.CustomRoles.dll</HintPath>
+    <Reference Include="Exiled.CustomRoles, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.CustomRoles.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Events, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.Events.dll</HintPath>
+    <Reference Include="Exiled.Events, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Loader, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.Loader.dll</HintPath>
+    <Reference Include="Exiled.Loader, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.Loader.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Permissions, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.Permissions.dll</HintPath>
+    <Reference Include="Exiled.Permissions, Version=5.2.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.Permissions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\Exiled.Updater.dll</HintPath>
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\Exiled.Updater.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(EXILED_REFERENCES)\Mirror.dll</HintPath>
     </Reference>
     <Reference Include="NorthwoodLib, Version=1.2.1.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\EXILED.5.1.0-beta.8\lib\net472\NorthwoodLib.dll</HintPath>
+      <HintPath>..\packages\EXILED.5.2.2\lib\net472\NorthwoodLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -111,7 +112,7 @@
       <HintPath>$(EXILED_REFERENCES)\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet, Version=9.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e">
-      <HintPath>..\..\EXILED\bin\Release\YamlDotNet.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\EXILED VISUAL STUDIO\EXILED 5\5.2\dependencies\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CustomItems/Items/EmpGrenade.cs
+++ b/CustomItems/Items/EmpGrenade.cs
@@ -164,7 +164,7 @@ namespace CustomItems.Items
             foreach (Door door in room.Doors)
             {
                 if (door == null ||
-                    (!string.IsNullOrEmpty(door.Nametag) && BlacklistedDoorTypes.Contains(door.Type)) ||
+                    BlacklistedDoorTypes.Contains(door.Type) ||
                     (door.DoorLockType > 0 && !OpenLockedDoors) ||
                     (door.RequiredPermissions.RequiredPermissions != KeycardPermissions.None && !OpenKeycardDoors))
                     continue;

--- a/CustomItems/Items/EmpGrenade.cs
+++ b/CustomItems/Items/EmpGrenade.cs
@@ -97,7 +97,7 @@ namespace CustomItems.Items
         /// Gets or sets a value indicating what doors will never be opened by EMP grenades.
         /// </summary>
         [Description("A list of door names that will not be opened with EMP grenades regardless of the above configs.")]
-        public HashSet<string> BlacklistedDoorNames { get; set; } = new HashSet<string>();
+        public HashSet<DoorType> BlacklistedDoorNames { get; set; } = new HashSet<DoorType>();
 
         /// <summary>
         /// Gets or sets a value indicating whether if tesla gates will get disabled.
@@ -164,7 +164,7 @@ namespace CustomItems.Items
             foreach (Door door in room.Doors)
             {
                 if (door == null ||
-                    (!string.IsNullOrEmpty(door.Nametag) && BlacklistedDoorNames.Contains(door.Nametag)) ||
+                    (!string.IsNullOrEmpty(door.Nametag) && BlacklistedDoorNames.Contains(door.Type)) ||
                     (door.DoorLockType > 0 && !OpenLockedDoors) ||
                     (door.RequiredPermissions.RequiredPermissions != KeycardPermissions.None && !OpenKeycardDoors))
                     continue;

--- a/CustomItems/Items/EmpGrenade.cs
+++ b/CustomItems/Items/EmpGrenade.cs
@@ -97,7 +97,7 @@ namespace CustomItems.Items
         /// Gets or sets a value indicating what doors will never be opened by EMP grenades.
         /// </summary>
         [Description("A list of door names that will not be opened with EMP grenades regardless of the above configs.")]
-        public HashSet<DoorType> BlacklistedDoorNames { get; set; } = new HashSet<DoorType>();
+        public HashSet<DoorType> BlacklistedDoorTypes { get; set; } = new HashSet<DoorType>();
 
         /// <summary>
         /// Gets or sets a value indicating whether if tesla gates will get disabled.
@@ -164,7 +164,7 @@ namespace CustomItems.Items
             foreach (Door door in room.Doors)
             {
                 if (door == null ||
-                    (!string.IsNullOrEmpty(door.Nametag) && BlacklistedDoorNames.Contains(door.Type)) ||
+                    (!string.IsNullOrEmpty(door.Nametag) && BlacklistedDoorTypes.Contains(door.Type)) ||
                     (door.DoorLockType > 0 && !OpenLockedDoors) ||
                     (door.RequiredPermissions.RequiredPermissions != KeycardPermissions.None && !OpenKeycardDoors))
                     continue;

--- a/CustomItems/Items/TranquilizerGun.cs
+++ b/CustomItems/Items/TranquilizerGun.cs
@@ -185,7 +185,7 @@ namespace CustomItems.Items
                         {
                             if (TryGet(item, out CustomItem customItem))
                             {
-                                customItem.Spawn(player.Position, item);
+                                customItem.Spawn(player.Position, item, player);
                                 player.RemoveItem(item);
                             }
                         }

--- a/CustomItems/packages.config
+++ b/CustomItems/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="5.1.0-beta.8" targetFramework="net472" />
+  <package id="EXILED" version="5.2.2" targetFramework="net472" />
   <package id="Lib.Harmony" version="2.0.4" targetFramework="net472" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
I converted the HashSet (STRING) to HashSet (DOORTYPE) in the EMP Grenade Config
Updated the Refs to Exiled 5.2.2 and now some items that use the Spawn method are now using the Exiled 5.2.2 Spawn Method